### PR TITLE
Create manifest.json

### DIFF
--- a/wavin/manifest.json
+++ b/wavin/manifest.json
@@ -1,0 +1,11 @@
+{
+    "domain": "wavin",
+    "name": "wavin ahc9000",
+    "version": "1.0.0",
+    "documentation": "https://github.com/plazmdk/homeassistant-wavin",
+    "requirements": [],
+    "dependencies": [],
+    "codeowners": [
+        "@plazmdk"
+    ]
+}


### PR DESCRIPTION
After recent update in homeassistant core, manifest file is mandatory for custom components.
The proposed manifest file is only validated on my system.